### PR TITLE
EGL: Add glfwGetEGLConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ information on what to include when reporting a bug.
  - [EGL] Added ANGLE backend selection via `EGL_ANGLE_platform_angle` extension
    (#1380)
  - [EGL] Bugfix: The `GLFW_DOUBLEBUFFER` context attribute was ignored (#1843)
+ - [EGL] Made it possible to query the `EGLConfig` that was chosen to create a given window via `glfwGetEGLConfig`
 
 
 ## Contact

--- a/docs/news.dox
+++ b/docs/news.dox
@@ -70,6 +70,12 @@ enabling keyboard access to the window menu via the Alt+Space and
 Alt-and-then-Space shortcuts.  This may be useful for more GUI-oriented
 applications.
 
+@subsubsection features_34_egl_getconfig Query EGLConfig
+
+GLFW now provides the [glfwGetEGLConfig](@ref glfwGetEGLConfig)
+function that returns the EGLConfig that was chosen to create the
+given window handle.
+
 
 @subsection caveats Caveats for version 3.4
 
@@ -180,6 +186,7 @@ then GLFW will fail to initialize.
  - @ref glfwGetPlatform
  - @ref glfwPlatformSupported
  - @ref glfwInitVulkanLoader
+ - @ref glfwGetEGLConfig
 
 
 @subsubsection types_34 New types in version 3.4

--- a/include/GLFW/glfw3native.h
+++ b/include/GLFW/glfw3native.h
@@ -517,6 +517,24 @@ GLFWAPI EGLContext glfwGetEGLContext(GLFWwindow* window);
  *  @ingroup native
  */
 GLFWAPI EGLSurface glfwGetEGLSurface(GLFWwindow* window);
+
+
+/*! @brief Returns the `EGLConfig` of the specified window.
+ *
+ *  @return The `EGLConfig` of the specified window, or `EGL_NO_SURFACE` if an
+ *  [error](@ref error_handling) occurred.
+ *
+ *  @errors Possible errors include @ref GLFW_NO_WINDOW_CONTEXT and @ref
+ *  GLFW_NOT_INITIALIZED.
+ *
+ *  @thread_safety This function may be called from any thread.  Access is not
+ *  synchronized.
+ *
+ *  @since Added in version 3.0.
+ *
+ *  @ingroup native
+ */
+GLFWAPI EGLConfig glfwGetEGLConfig(GLFWwindow* window);
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_OSMESA)

--- a/src/egl_context.c
+++ b/src/egl_context.c
@@ -866,3 +866,17 @@ GLFWAPI EGLSurface glfwGetEGLSurface(GLFWwindow* handle)
     return window->context.egl.surface;
 }
 
+GLFWAPI EGLConfig glfwGetEGLConfig(GLFWwindow* handle)
+{
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFW_REQUIRE_INIT_OR_RETURN(EGL_NO_SURFACE);
+
+    if (window->context.source != GLFW_EGL_CONTEXT_API)
+    {
+        _glfwInputError(GLFW_NO_WINDOW_CONTEXT, NULL);
+        return EGL_NO_SURFACE;
+    }
+
+    return window->context.egl.config;
+}
+


### PR DESCRIPTION
I have been working on OpenXR + OpenGL Linux support today, and I again encountered a limitation in GLFW: in order to complete the EGL-based session construction, I need `glfwGetEGLConfig` (not to be confused with `glfwGetGLXFBConfig` which is needed for X11-based sessions). Currently, EGL-based sessions seem to work on my Linux laptop if I hardcode the right EGL config, but that is obviously not portable (but it is an indication that I'm on the right track).

I would rather test this on LWJGL before bothering the maintainer of GLFW. Once everything works, it's time to rebase the other pull request and submit this one.